### PR TITLE
Added options and efficiency

### DIFF
--- a/ParticleOverdrive/Controllers/CameraNoiseController.cs
+++ b/ParticleOverdrive/Controllers/CameraNoiseController.cs
@@ -57,20 +57,20 @@ namespace ParticleOverdrive.Controllers
 
         private void Set()
         {
-            BlueNoiseDithering _blueNoiseDithering = DitheringUpdater.GetField<BlueNoiseDithering>("_blueNoiseDithering");
+            BlueNoiseDithering _blueNoiseDithering = Plugin.GetBlueNoiseDithering(DitheringUpdater);
 
             if (_originalNoise == null)
             {
                 Logger.Log("Noise texture unset, caching original value...");
-                Texture2D orig = _blueNoiseDithering.GetField<Texture2D>("_noiseTexture");
+                Texture2D orig = Plugin.GetNoiseTexture(_blueNoiseDithering);
 
                 _originalNoise = orig;
             }
 
             if (_enabled)
-                _blueNoiseDithering.SetField("_noiseTexture", _originalNoise);
+                Plugin.GetNoiseTexture(_blueNoiseDithering) = _originalNoise;
             else
-                _blueNoiseDithering.SetField("_noiseTexture", _newNoise);
+                Plugin.GetNoiseTexture(_blueNoiseDithering) = _newNoise;
         }
 
         private BlueNoiseDitheringUpdater Find()

--- a/ParticleOverdrive/Misc/Config.cs
+++ b/ParticleOverdrive/Misc/Config.cs
@@ -31,6 +31,19 @@ namespace ParticleOverdrive.Misc
             }
         }
 
+        static readonly string slashParticleLifetimeMultiplier = "SlashParticleLifetimeMultiplier";
+        internal static float SlashParticleLifetimeMultiplier
+        {
+            get
+            {
+                return config.GetFloat(sectionParticles, slashParticleLifetimeMultiplier, 1.0f, true);
+            }
+            set
+            {
+                config.SetFloat(sectionParticles, slashParticleLifetimeMultiplier, value);
+            }
+        }
+
         static readonly string explosionParticleMultiplier = "ExplosionParticleMultiplier";
         internal static float ExplosionParticleMultiplier
         {
@@ -41,6 +54,32 @@ namespace ParticleOverdrive.Misc
             set
             {
                 config.SetFloat(sectionParticles, explosionParticleMultiplier, value);
+            }
+        }
+
+        static readonly string explosionParticleLifetimeMultiplier = "ExplosionParticleLifetimeMultiplier";
+        internal static float ExplosionParticleLifetimeMultiplier
+        {
+            get
+            {
+                return config.GetFloat(sectionParticles, explosionParticleLifetimeMultiplier, 1.0f, true);
+            }
+            set
+            {
+                config.SetFloat(sectionParticles, explosionParticleLifetimeMultiplier, value);
+            }
+        }
+
+        static readonly string rainbowParticles = "RainbowParticles";
+        internal static bool RainbowParticles
+        {
+            get
+            {
+                return config.GetBool(sectionParticles, rainbowParticles, false, true);
+            }
+            set
+            {
+                config.SetBool(sectionParticles, rainbowParticles, value);
             }
         }
 

--- a/ParticleOverdrive/ParticleOverdrive.csproj
+++ b/ParticleOverdrive/ParticleOverdrive.csproj
@@ -23,12 +23,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
@@ -90,6 +92,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Controllers\WorldParticleController.cs" />
     <Compile Include="UI\POUI.cs" />
+    <Compile Include="Utilities.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="manifest.json" />

--- a/ParticleOverdrive/Patches/NoteCutParticlesEffectSpawnParticles.cs
+++ b/ParticleOverdrive/Patches/NoteCutParticlesEffectSpawnParticles.cs
@@ -15,17 +15,20 @@ namespace ParticleOverdrive.Patches
     {
         internal static void Prefix(ref NoteCutParticlesEffect __instance, ref Color32 color, ref int sparkleParticlesCount, ref int explosionParticlesCount, ref float lifetimeMultiplier)
         {
-            var ____explosionPS = Plugin.GetExplosionPS(__instance);
-            var ____sparklesPS = Plugin.GetSparklesPS(__instance);
+            ParticleSystem explosionPS = Plugin.GetExplosionPS(__instance);
+            ParticleSystem[] sparklesPSAry = Plugin.GetSparklesPS(__instance);
 
             sparkleParticlesCount = Mathf.FloorToInt(sparkleParticlesCount * Plugin.SlashParticleMultiplier);
             explosionParticlesCount = Mathf.FloorToInt(explosionParticlesCount * Plugin.ExplosionParticleMultiplier);
             lifetimeMultiplier *= Plugin.SlashParticleLifetimeMultiplier;
             if (Plugin.RainbowParticles)
                 color = UnityEngine.Random.ColorHSV();
-            ParticleSystem.MainModule slashMain = ____sparklesPS[0].main;
-            slashMain.maxParticles = int.MaxValue;
-            ParticleSystem.MainModule explosionMain = ____explosionPS.main;
+            for (int i = 0; i < sparklesPSAry.Length; i++)
+            {
+                ParticleSystem.MainModule slashMain = sparklesPSAry[i].main;
+                slashMain.maxParticles = int.MaxValue;
+            }
+            ParticleSystem.MainModule explosionMain = explosionPS.main;
             explosionMain.maxParticles = int.MaxValue;
             explosionMain.startLifetimeMultiplier = Plugin.ExplosionParticleLifetimeMultiplier;
         }

--- a/ParticleOverdrive/Patches/NoteCutParticlesEffectSpawnParticles.cs
+++ b/ParticleOverdrive/Patches/NoteCutParticlesEffectSpawnParticles.cs
@@ -4,6 +4,8 @@ using Harmony;
 using UnityEngine;
 using ParticleOverdrive.Misc;
 using BS_Utils.Utilities;
+using System.Reflection.Emit;
+using System.Reflection;
 
 namespace ParticleOverdrive.Patches
 {
@@ -11,9 +13,11 @@ namespace ParticleOverdrive.Patches
     [HarmonyPatch("SpawnParticles")]
     class NoteCutParticlesEffectSpawnParticles
     {
-        internal static void Prefix(ref NoteCutParticlesEffect __instance, ref Color32 color, ref int sparkleParticlesCount, ref int explosionParticlesCount, ref float lifetimeMultiplier,
-            ref ParticleSystem[] ____sparklesPS, ref ParticleSystem ____explosionPS)
+        internal static void Prefix(ref NoteCutParticlesEffect __instance, ref Color32 color, ref int sparkleParticlesCount, ref int explosionParticlesCount, ref float lifetimeMultiplier)
         {
+            var ____explosionPS = Plugin.GetExplosionPS(__instance);
+            var ____sparklesPS = Plugin.GetSparklesPS(__instance);
+
             sparkleParticlesCount = Mathf.FloorToInt(sparkleParticlesCount * Plugin.SlashParticleMultiplier);
             explosionParticlesCount = Mathf.FloorToInt(explosionParticlesCount * Plugin.ExplosionParticleMultiplier);
             lifetimeMultiplier *= Plugin.SlashParticleLifetimeMultiplier;
@@ -25,5 +29,6 @@ namespace ParticleOverdrive.Patches
             explosionMain.maxParticles = int.MaxValue;
             explosionMain.startLifetimeMultiplier = Plugin.ExplosionParticleLifetimeMultiplier;
         }
+
     }
 }

--- a/ParticleOverdrive/Patches/NoteCutParticlesEffectSpawnParticles.cs
+++ b/ParticleOverdrive/Patches/NoteCutParticlesEffectSpawnParticles.cs
@@ -11,24 +11,19 @@ namespace ParticleOverdrive.Patches
     [HarmonyPatch("SpawnParticles")]
     class NoteCutParticlesEffectSpawnParticles
     {
-        static void Prefix(ref NoteCutParticlesEffect __instance, ref int sparkleParticlesCount, ref int explosionParticlesCount)
+        internal static void Prefix(ref NoteCutParticlesEffect __instance, ref Color32 color, ref int sparkleParticlesCount, ref int explosionParticlesCount, ref float lifetimeMultiplier,
+            ref ParticleSystem[] ____sparklesPS, ref ParticleSystem ____explosionPS)
         {
-            float slashMulti = Plugin.SlashParticleMultiplier;
-            float exploMulti = Plugin.ExplosionParticleMultiplier;
-
-            ParticleSystem[] slashPS = (ParticleSystem[])__instance.GetField("_sparklesPS");
-            foreach (ParticleSystem ps in slashPS)
-            {
-                ParticleSystem.MainModule main = ps.main;
-                main.maxParticles = 150 * Mathf.FloorToInt(slashMulti * 2f);
-            }
-
-            sparkleParticlesCount = 150 * Mathf.FloorToInt(slashMulti);
-
-            ParticleSystem.MainModule exploPS = ((ParticleSystem)__instance.GetField("_explosionPS")).main;
-
-            explosionParticlesCount = 150 * Mathf.FloorToInt(exploMulti);
-            exploPS.maxParticles = 150 * Mathf.FloorToInt(exploMulti * 2f);
+            sparkleParticlesCount = Mathf.FloorToInt(sparkleParticlesCount * Plugin.SlashParticleMultiplier);
+            explosionParticlesCount = Mathf.FloorToInt(explosionParticlesCount * Plugin.ExplosionParticleMultiplier);
+            lifetimeMultiplier *= Plugin.SlashParticleLifetimeMultiplier;
+            if (Plugin.RainbowParticles)
+                color = UnityEngine.Random.ColorHSV();
+            ParticleSystem.MainModule slashMain = ____sparklesPS[0].main;
+            slashMain.maxParticles = int.MaxValue;
+            ParticleSystem.MainModule explosionMain = ____explosionPS.main;
+            explosionMain.maxParticles = int.MaxValue;
+            explosionMain.startLifetimeMultiplier = Plugin.ExplosionParticleLifetimeMultiplier;
         }
     }
 }

--- a/ParticleOverdrive/Plugin.cs
+++ b/ParticleOverdrive/Plugin.cs
@@ -24,6 +24,16 @@ namespace ParticleOverdrive
         public static WorldParticleController _particleController;
         public static CameraNoiseController _noiseController;
 
+        #region Private Field Getters
+
+        internal static RefGetter<NoteCutParticlesEffect, ParticleSystem> GetExplosionPS;
+        internal static RefGetter<NoteCutParticlesEffect, ParticleSystem[]> GetSparklesPS;
+        internal static RefGetter<BlueNoiseDitheringUpdater, BlueNoiseDithering> GetBlueNoiseDithering;
+        internal static RefGetter<BlueNoiseDithering, Texture2D> GetNoiseTexture;
+        #endregion
+
+        internal static bool Enabled;
+
         public static readonly string ModPrefsKey = "ParticleOverdrive";
 
         public static float SlashParticleMultiplier;
@@ -50,6 +60,21 @@ namespace ParticleOverdrive
 
         public void OnApplicationStart()
         {
+            try
+            {
+                GetExplosionPS = Utilities.CreateRefGetter<NoteCutParticlesEffect, ParticleSystem>("_explosionPS");
+                GetSparklesPS = Utilities.CreateRefGetter<NoteCutParticlesEffect, ParticleSystem[]>("_sparklesPS");
+                GetBlueNoiseDithering = Utilities.CreateRefGetter<BlueNoiseDitheringUpdater, BlueNoiseDithering>("_blueNoiseDithering");
+                GetNoiseTexture = Utilities.CreateRefGetter<BlueNoiseDithering, Texture2D>("_noiseTexture");
+            }
+            catch(Exception ex)
+            {
+                log.Error($"Error creating private field accessors, ParticleOverdrive cannot load: {ex.Message}");
+                log.Debug(ex);
+                Enabled = false;
+                return;
+            }
+
             LoadConfig();
             try
             {
@@ -76,6 +101,8 @@ namespace ParticleOverdrive
 
         public void OnActiveSceneChanged(Scene _, Scene scene)
         {
+            if (!Enabled)
+                return;
             LoadConfig();
             if (_controller == null)
             {

--- a/ParticleOverdrive/Plugin.cs
+++ b/ParticleOverdrive/Plugin.cs
@@ -27,6 +27,9 @@ namespace ParticleOverdrive
 
         public static float SlashParticleMultiplier;
         public static float ExplosionParticleMultiplier;
+        public static float SlashParticleLifetimeMultiplier;
+        public static float ExplosionParticleLifetimeMultiplier;
+        public static bool RainbowParticles;
 
         public void Init(IPA.Logging.Logger logger)
         {
@@ -34,11 +37,18 @@ namespace ParticleOverdrive
             Logger.logger = logger;
         }
 
-        public void OnApplicationStart()
+        public void LoadConfig()
         {
             SlashParticleMultiplier = Config.SlashParticleMultiplier;
             ExplosionParticleMultiplier = Config.ExplosionParticleMultiplier;
+            SlashParticleLifetimeMultiplier = Config.SlashParticleLifetimeMultiplier;
+            ExplosionParticleLifetimeMultiplier = Config.ExplosionParticleLifetimeMultiplier;
+            RainbowParticles = Config.RainbowParticles;
+        }
 
+        public void OnApplicationStart()
+        {
+            LoadConfig();
             try
             {
                 HarmonyInstance harmony = HarmonyInstance.Create("com.jackbaron.beatsaber.particleoverdrive");
@@ -60,6 +70,7 @@ namespace ParticleOverdrive
 
         public void OnActiveSceneChanged(Scene _, Scene scene)
         {
+            LoadConfig();
             if (_controller == null)
             {
                 _controller = new GameObject("WorldEffectController");

--- a/ParticleOverdrive/Plugin.cs
+++ b/ParticleOverdrive/Plugin.cs
@@ -16,6 +16,7 @@ namespace ParticleOverdrive
     {
         public string Name => "Particle Overdive";
         public string Version => "1.0.0";
+        IPA.Logging.Logger log;
 
         private static readonly string[] env = { "Init", "MenuViewControllers", "GameCore", "Credits" };
 
@@ -34,6 +35,7 @@ namespace ParticleOverdrive
         public void Init(IPA.Logging.Logger logger)
         {
             Config.Init();
+            log = logger;
             Logger.logger = logger;
         }
 
@@ -56,9 +58,13 @@ namespace ParticleOverdrive
             }
             catch (Exception e)
             {
-                Logger.Log("This plugin requires Harmony. Make sure you " +
-                    "installed the plugin properly, as the Harmony DLL should have been installed with it.");
-                Console.WriteLine(e);
+                if (e.InnerException is ArgumentException argEx)
+                {
+                    log.Error($"Error applying Harmony patches. {argEx.Message}.");//: {argEx.ParamName}");
+                }
+                else
+                    log.Error($"Error applying Harmony patches: {e.Message}");
+                log.Debug(e);
             }
 
         }

--- a/ParticleOverdrive/Plugin.cs
+++ b/ParticleOverdrive/Plugin.cs
@@ -65,7 +65,7 @@ namespace ParticleOverdrive
             try
             {
                 GetBlueNoiseDithering = Utilities.CreateRefGetter<BlueNoiseDitheringUpdater, BlueNoiseDithering>("_blueNoiseDithering");
-                GetNoiseTexture = Utilities.CreateRefGetter<BlueNoiseDithering, Texture2D>("_nnoiseTexture");
+                GetNoiseTexture = Utilities.CreateRefGetter<BlueNoiseDithering, Texture2D>("_noiseTexture");
                 CameraNoiseWorldParticlesEnabled = true;
             }
             catch (Exception ex)

--- a/ParticleOverdrive/UI/POUI.bsml
+++ b/ParticleOverdrive/UI/POUI.bsml
@@ -2,5 +2,8 @@
   <bool-setting text='Camera Noise' value='cameraNoiseEnable'></bool-setting>
   <bool-setting text='Global Dust Particles' value='dustParticleEnable'></bool-setting>
   <list-setting text='Slash Particles' value='slashParticleChoice' choices='slashParticleChoices' formatter='multiplierFormatter'></list-setting>
+  <list-setting text='Slash Particle Lifetime' value='slashParticleLifetimeChoice' choices='lifetimeChoices' formatter='multiplierFormatter'></list-setting>
   <list-setting text='Explosion Particles' value='explosionParticleChoice' choices='explosionParticleChoices' formatter='multiplierFormatter'></list-setting>
+  <list-setting text='Explosion Particle Lifetime' value='explosionParticleLifetimeChoice' choices='lifetimeChoices' formatter='multiplierFormatter'></list-setting>
+  <bool-setting text='RainbowParticles' value='rainbowParticlesEnable'></bool-setting>
 </settings-container>

--- a/ParticleOverdrive/UI/POUI.cs
+++ b/ParticleOverdrive/UI/POUI.cs
@@ -140,7 +140,9 @@ namespace ParticleOverdrive.UI
             get => Config.CameraGrain;
             set
             {
-                Plugin._noiseController.Enabled = value;
+
+                if (Plugin.CameraNoiseWorldParticlesEnabled)
+                    Plugin._noiseController.Enabled = value;
                 Config.CameraGrain = value;
             }
         }
@@ -152,7 +154,8 @@ namespace ParticleOverdrive.UI
             get => Config.DustParticles;
             set
             {
-                Plugin._particleController.Enabled = value;
+                if (Plugin.CameraNoiseWorldParticlesEnabled)
+                    Plugin._particleController.Enabled = value;
                 Config.DustParticles = value;
             }
         }
@@ -219,7 +222,7 @@ namespace ParticleOverdrive.UI
         }
 
         [UIAction("multiplierFormatter")]
-        public string multiplierDisplay (float multiplier)
+        public string multiplierDisplay(float multiplier)
         {
             return $"{multiplier * 100f}%";
         }

--- a/ParticleOverdrive/UI/POUI.cs
+++ b/ParticleOverdrive/UI/POUI.cs
@@ -6,6 +6,7 @@ namespace ParticleOverdrive.UI
 {
     public class POUI : PersistentSingleton<POUI>
     {
+        internal const float Infinity = 100000f;
         public static readonly List<object> particleMultiplierChoicesList = new List<object>()
         {
             0f,
@@ -84,12 +85,53 @@ namespace ParticleOverdrive.UI
             190f,
             200f
         };
+        [UIValue("lifetime-values")]
+        internal static List<object> LifetimeValues = new List<object>
+            {
+                0f,
+                0.1f,
+                0.2f,
+                0.3f,
+                0.4f,
+                0.5f,
+                0.6f,
+                0.7f,
+                0.8f,
+                0.9f,
+                1f,
+                1.1f,
+                1.2f,
+                1.3f,
+                1.4f,
+                1.5f,
+                1.6f,
+                1.7f,
+                1.8f,
+                1.9f,
+                2f,
+                2.25f,
+                2.5f,
+                2.75f,
+                3f,
+                3.25f,
+                3.5f,
+                3.75f,
+                4f,
+                4.25f,
+                4.5f,
+                4.75f,
+                5f,
+                Infinity,
+            };
 
         [UIValue("slashParticleChoices")]
         private List<object> _slashParticleMultiplierChoices = particleMultiplierChoicesList;
 
         [UIValue("explosionParticleChoices")]
         private List<object> _explosionParticleMultiplierChoices = particleMultiplierChoicesList;
+
+        [UIValue("lifetimeChoices")]
+        private List<object> _lifetimeChoices = LifetimeValues;
 
         [UIValue("cameraNoiseEnable")]
         public bool _cameraNoiseEnable
@@ -127,6 +169,18 @@ namespace ParticleOverdrive.UI
             }
         }
 
+        [UIValue("slashParticleLifetimeChoice")]
+        public float _slashParticleLifetimeMultiplier
+        {
+            //get => Config.SlashParticleMultiplier;
+            get => Config.SlashParticleLifetimeMultiplier;
+            set
+            {
+                Plugin.SlashParticleLifetimeMultiplier = value;
+                Config.SlashParticleLifetimeMultiplier = value;
+            }
+        }
+
         [UIValue("explosionParticleChoice")]
         public float _explosionParticleMultiplier
         {
@@ -136,6 +190,31 @@ namespace ParticleOverdrive.UI
             {
                 Plugin.ExplosionParticleMultiplier = value;
                 Config.ExplosionParticleMultiplier = value;
+            }
+        }
+
+
+        [UIValue("explosionParticleLifetimeChoice")]
+        public float _explosionParticleLifetimeMultiplier
+        {
+            //get => Config.SlashParticleMultiplier;
+            get => Config.ExplosionParticleLifetimeMultiplier;
+            set
+            {
+                Plugin.ExplosionParticleLifetimeMultiplier = value;
+                Config.ExplosionParticleLifetimeMultiplier = value;
+            }
+        }
+
+        [UIValue("rainbowParticlesEnable")]
+        public bool _rainbowParticlesEnable
+        {
+            //get => Plugin._noiseController.Enabled;
+            get => Config.RainbowParticles;
+            set
+            {
+                Plugin.RainbowParticles = value;
+                Config.RainbowParticles = value;
             }
         }
 

--- a/ParticleOverdrive/Utilities.cs
+++ b/ParticleOverdrive/Utilities.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ParticleOverdrive
+{
+    public delegate ref U RefGetter<T, U>(T obj);
+    public static class Utilities
+    {
+        /// <summary>
+        /// Creates a delegate to retrieve a reference to an object's private field (very fast).
+        /// </summary>
+        /// <typeparam name="T"><see cref="Type"/> of class the private field belongs to.</typeparam>
+        /// <typeparam name="U"><see cref="Type"/> of the private field.</typeparam>
+        /// <param name="s_field">Name of the private field</param>
+        /// <returns><see cref="RefGetter{T, U}"/> delegate to reference the private field.</returns>
+        /// <remarks>From: https://stackoverflow.com/a/45046664 </remarks>
+        public static RefGetter<T, U> CreateRefGetter<T, U>(string s_field)
+        {
+            const BindingFlags bf = BindingFlags.NonPublic |
+                                    BindingFlags.Instance |
+                                    BindingFlags.DeclaredOnly;
+
+            var fi = typeof(T).GetField(s_field, bf);
+            if (fi == null)
+                throw new MissingFieldException(typeof(T).Name, s_field);
+
+            var s_name = "__refget_" + typeof(T).Name + "_fi_" + fi.Name;
+
+            // workaround for using ref-return with DynamicMethod:
+            //   a.) initialize with dummy return value
+            var dm = new DynamicMethod(s_name, typeof(U), new[] { typeof(T) }, typeof(T), true);
+
+            //   b.) replace with desired 'ByRef' return value
+            var f_returnType = dm.GetType().GetField("m_returnType", bf);
+            if (f_returnType == null)
+                f_returnType = dm.GetType().GetField("returnType", bf); // For Unity/Mono
+
+            f_returnType.SetValue(dm, typeof(U).MakeByRefType());
+
+
+            var il = dm.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldflda, fi);
+            il.Emit(OpCodes.Ret);
+
+            return (RefGetter<T, U>)dm.CreateDelegate(typeof(RefGetter<T, U>));
+        }
+    }
+}


### PR DESCRIPTION
* Reworked the Harmony patch for a bit more efficiency by using Harmony parameters to get the private fields instead of Reflection.
* Added options for slash and explosion particle lifetime.
* Added option for rainbow particles.
* Config gets read from the file OnActiveSceneChanged
* Replaced all Get/Set Fields with a fancy RefGetter, almost as fast as accessing the field directly.
  * All RefGetter delegates are created OnApplicationStart
  * RefGetters for for Camera Noise/World Particles and Slash/Explosion Particles are in their own try/catch blocks so if one of them fails (game update breaks it), the other will still function.