### PR TITLE
Modify RainbowParticles color

### DIFF
--- a/ParticleOverdrive/Patches/NoteCutParticlesEffectSpawnParticles.cs
+++ b/ParticleOverdrive/Patches/NoteCutParticlesEffectSpawnParticles.cs
@@ -22,7 +22,7 @@ namespace ParticleOverdrive.Patches
             explosionParticlesCount = Mathf.FloorToInt(explosionParticlesCount * Plugin.ExplosionParticleMultiplier);
             lifetimeMultiplier *= Plugin.SlashParticleLifetimeMultiplier;
             if (Plugin.RainbowParticles)
-                color = UnityEngine.Random.ColorHSV();
+                color = UnityEngine.Random.ColorHSV(0, 1, 1, 1, 1, 1, 1, 1);
             for (int i = 0; i < sparklesPSAry.Length; i++)
             {
                 ParticleSystem.MainModule slashMain = sparklesPSAry[i].main;


### PR DESCRIPTION
One line change to use a Random.ColorHSV() overload to only randomize the hue. (As seen [here](https://docs.unity3d.com/ScriptReference/Random.ColorHSV.html))

This should cause colors from RainbowParticles to be more vibrant.